### PR TITLE
Win32 build system

### DIFF
--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -40,9 +40,9 @@ HEADERS = mainwindow.h \
     dialogsettingseditor.h \
     drawersettingseditor.h \
     scrollbarsettingseditor.h
-LIBS += $$top_builddir/components/libcomponents.a
+LIBS += $$top_builddir/components/$(OBJECTS_DIR)/libcomponents.a
 INCLUDEPATH += $$top_srcdir/components/
-TARGET = $$top_builddir/examples-exe
+TARGET = ../../examples-exe
 
 RESOURCES += \
     examples.qrc


### PR DESCRIPTION
I wrote a long description then I lost it... anyway,...
OBJECTS_DIR is release/ or debug/ in windows, empty in linux
TARGET don't accept absolute path (it gave me release/c:\cvs.......

Now it fully builds 