### PR TITLE
Dotted underline when TextField is disabled

### DIFF
--- a/components/qtmaterialtextfield.cpp
+++ b/components/qtmaterialtextfield.cpp
@@ -299,6 +299,10 @@ void QtMaterialTextField::paintEvent(QPaintEvent *event)
         QPen pen;
         pen.setWidth(1);
         pen.setColor(underlineColor());
+	if( !isEnabled() )
+	{
+	    pen.setStyle( Qt::DotLine );
+	}
         painter.setPen(pen);
         painter.setOpacity(1);
         painter.drawLine(2.5, y, wd, y);


### PR DESCRIPTION
I implemented according to material.io but it seems the dots are very small and they are not visible. the effect is a lighter line. But the color scheme of material.io requires a canvas color that is not white...